### PR TITLE
feat: Decrease number of re-renders on renderItem

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import {
   ScrollViewProps,
   StyleSheet,
   View,
+  ListRenderItem,
 } from 'react-native';
 import { FlatList } from '@stream-io/flat-list-mvcp';
 
@@ -26,6 +27,7 @@ type Props<T> = FlatListProps<T> & {
   FooterLoadingIndicator?: React.ComponentType;
   ListHeaderComponent?: React.ComponentType;
   ListFooterComponent?: React.ComponentType;
+  renderItem: ListRenderItem<T>;
 };
 
 /**
@@ -52,6 +54,7 @@ const BidirectionalFlatList = <T extends any>(props: Props<T>) => {
     onStartReached = () => Promise.resolve(),
     onStartReachedThreshold = 10,
     showDefaultLoadingIndicators = true,
+    renderItem,
   } = props;
 
   const [onStartReachedInProgress, setOnStartReachedInProgress] = useState(
@@ -187,6 +190,9 @@ const BidirectionalFlatList = <T extends any>(props: Props<T>) => {
     );
   };
 
+  const compareRenderItensEquality = (prevProps: any, nextProps: any) => prevProps.item === nextProps.item;
+  const MemoizedRenderItem = React.useCallback(React.memo(renderItem, compareRenderItensEquality), []);
+
   return (
     <>
       <FlatList
@@ -196,6 +202,7 @@ const BidirectionalFlatList = <T extends any>(props: Props<T>) => {
         ListFooterComponent={renderFooterLoadingIndicator}
         onEndReached={null}
         onScroll={handleScroll}
+        renderItem={(args: any) => <MemoizedRenderItem {...args} />}
         // @ts-ignore
         maintainVisibleContentPosition={{
           autoscrollToTopThreshold: undefined,


### PR DESCRIPTION
## Proposed changes
This PR is a modification made on how the renderItem method is called to prevent unecessary re-renders when the user is loading more items on the end or start of the list.
With this memoized renderItem call, when onStartReached or onEndReached is called adding new items to the list, only the newly created items, which were not memoized before, will call the renderItem passed as props to the `Flatlist`. Otherwise, all the items would be rendered again.
I needed to use React.memo with a compare function to memoize the rendering of the item and a React.useCallback to maintain the function instance after each Flatlist re-render, otherwise we wouldn't have a memoized return from the renderItem.

## Note
This is my first contribution and I couldn't install the dependencies with yarn or follow the other instructions in the Development workflow. I don't know why but `yarn` commands were not working and I couldn't make it work, other projects were okay with yarn. So I cloned the example app and was making modifications and testing the behaviour directly in the node_modules folder of that example.
With that in mind, I hope it can at least help with a direction towards how to optimize the re-rendering of the Flatlist items.

Looking forward to feedbacks :)